### PR TITLE
Update core-helpers to v0.3.1

### DIFF
--- a/shared/helpers.tofu
+++ b/shared/helpers.tofu
@@ -2,5 +2,5 @@
 # https://github.com/osinfra-io/pt-arche-core-helpers
 
 module "core_helpers" {
-  source = "github.com/osinfra-io/pt-arche-core-helpers//child?ref=1024a5446b33be60bba2d52897ba4f487cb469ed"  # v0.2.3
+  source = "github.com/osinfra-io/pt-arche-core-helpers//child?ref=70c1e4f4a11acdcfc36055bdd3aa16579d4203a1"  # v0.3.1
 }


### PR DESCRIPTION
Updates `pt-arche-core-helpers` to [v0.3.1](https://github.com/osinfra-io/pt-arche-core-helpers/releases/tag/v0.3.1) (`70c1e4f4a11acdcfc36055bdd3aa16579d4203a1`).