### PR TITLE
Declare providers for cert-manager submodules

### DIFF
--- a/regional/istio-csr/providers.tofu
+++ b/regional/istio-csr/providers.tofu
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+
+    # Helm Provider
+    # https://search.opentofu.org/provider/hashicorp/helm/latest/docs
+
+    helm = {
+      source = "hashicorp/helm"
+    }
+
+    # Kubernetes Provider
+    # https://search.opentofu.org/provider/hashicorp/kubernetes/latest/docs
+
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}

--- a/regional/providers.tofu
+++ b/regional/providers.tofu
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+
+    # Helm Provider
+    # https://search.opentofu.org/provider/hashicorp/helm/latest/docs
+
+    helm = {
+      source = "hashicorp/helm"
+    }
+  }
+}

--- a/shared/helpers.tofu
+++ b/shared/helpers.tofu
@@ -2,5 +2,5 @@
 # https://github.com/osinfra-io/pt-arche-core-helpers
 
 module "core_helpers" {
-  source = "github.com/osinfra-io/pt-arche-core-helpers//child?ref=70c1e4f4a11acdcfc36055bdd3aa16579d4203a1"  # v0.3.1
+  source = "github.com/osinfra-io/pt-arche-core-helpers//child?ref=70c1e4f4a11acdcfc36055bdd3aa16579d4203a1" # v0.3.1
 }


### PR DESCRIPTION
## Summary
- Add required_providers declarations for the regional cert-manager module and istio-csr submodule.
- Declare helm for regional and helm plus kubernetes for regional/istio-csr.
- Preserve child-module behavior by avoiding provider configuration blocks.

## Validation
- pre-commit run -a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for required infrastructure providers needed by the platform.
  * Expanded provider configuration to include the necessary deployment tooling components.
  * Made a minor formatting-only update to an existing shared configuration reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->