### PR TITLE
Remove unused artifact_registry variable

### DIFF
--- a/regional/istio-csr/variables.tofu
+++ b/regional/istio-csr/variables.tofu
@@ -1,12 +1,6 @@
 # Input Variables
 # https://opentofu.org/docs/language/values/variables
 
-variable "artifact_registry" {
-  description = "The registry to pull the images from"
-  type        = string
-  default     = "us-docker.pkg.dev/plt-lz-services-tf79-prod/plt-docker-virtual"
-}
-
 variable "cert_manager_istio_csr_version" {
   description = "The version to install for the Istio CSR, this is used for the chart as well as the image tag"
   type        = string

--- a/regional/variables.tofu
+++ b/regional/variables.tofu
@@ -1,12 +1,6 @@
 # Input Variables
 # https://opentofu.org/docs/language/values/variables
 
-variable "artifact_registry" {
-  description = "The registry to pull the images from"
-  type        = string
-  default     = "us-docker.pkg.dev/plt-lz-services-tf79-prod/plt-docker-virtual"
-}
-
 variable "cainjector_replicas" {
   description = "The number of replicas to run for the cainjector"
   type        = number

--- a/tests/fixtures/default/regional/istio-csr/main.tofu
+++ b/tests/fixtures/default/regional/istio-csr/main.tofu
@@ -21,7 +21,6 @@ terraform {
 module "test" {
   source = "../../../../../regional/istio-csr"
 
-  artifact_registry                           = "mock-docker.pkg.dev/mock-project/mock-virtual"
   cluster_prefix                              = "mock-cluster"
   tls_self_signed_cert_cert_manager_root_cert = "mock-cert"
   tls_self_signed_cert_cert_manager_root_key  = "mock-key"

--- a/tests/fixtures/default/regional/main.tofu
+++ b/tests/fixtures/default/regional/main.tofu
@@ -20,6 +20,4 @@ terraform {
 
 module "test" {
   source = "../../../../regional"
-
-  artifact_registry = "mock-docker.pkg.dev/mock-project/mock-virtual"
 }


### PR DESCRIPTION
Removes `variable "artifact_registry"` from `regional/variables.tofu` and `regional/istio-csr/variables.tofu`. The variable was defined but never referenced in any locals or resource blocks in either module. Also removes the corresponding argument from the two test fixtures that were passing it in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the obsolete artifact registry configuration from regional deployment settings.
  * Simplified default test configurations by eliminating the unused artifact registry input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->