### PR TITLE
Suppress IST0118 warning for cert-manager webhook metrics port

### DIFF
--- a/regional/helm/cert-manager.yml
+++ b/regional/helm/cert-manager.yml
@@ -4,3 +4,9 @@ crds:
 global:
   commonLabels:
     tags.datadoghq.com/source: cert-manager
+
+webhook:
+  serviceAnnotations:
+    # IST0118: Port name 'metrics' doesn't follow Istio naming convention.
+    # The chart doesn't support customizing port names, so we suppress the warning.
+    galley.istio.io/analyze-suppress: IST0118


### PR DESCRIPTION
## Summary

The cert-manager webhook Service has a metrics port named `metrics` instead of Istio's preferred `http-metrics` convention. The chart doesn't support customizing port names, so we suppress the analyzer warning via `serviceAnnotations`.

## Changes

Added `webhook.serviceAnnotations` with `galley.istio.io/analyze-suppress: IST0118` to the Helm values.

## Related

- Issue #71 tracks upstream work to add `serviceAnnotations` support to the istio-csr chart for the remaining IST0118 warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed a non-actionable service port naming warning for the certificate management webhook.
  * Added service configuration to support cleaner Istio analysis results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->